### PR TITLE
Add failure exit code on RPM build failure

### DIFF
--- a/rpmvenv/cmd.py
+++ b/rpmvenv/cmd.py
@@ -212,6 +212,7 @@ def main():
             exc.stdout,
             os.linesep,
         ))
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='rpmvenv',
-    version='0.3.0',
+    version='0.3.1',
     url='https://github.com/kevinconway/rpmvenv',
     description='RPM packager for Python virtualenv.',
     author="Kevin Conway",


### PR DESCRIPTION
Previously this was accomplished by allowing the exceptions to
bubble up. Now that we catch the exception we need to exit with
a non-zero code.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>