### PR TITLE
Add support for custom RPM package names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,10 @@ values are as follows::
 
     -   macros => RPM macro definitions.
 
-        -   pkg_name => The name of the RPM package.
+        -   pkg_name => The name of the directory containing the package
+                content.
+
+        -   pkg_rpm_name => The name of the RPM.
 
         -   pkg_version => The version number to assign the RPM.
 

--- a/rpmvenv/cmd.py
+++ b/rpmvenv/cmd.py
@@ -95,9 +95,10 @@ def build(source, config):
 
     top = rpmbuild.topdir()
     specfile = rpmbuild.write_spec(top, specfile)
-    rpmbuild.copy_source(top, source)
+    rpmbuild.copy_source(top, source, name=macros['pkg_name'])
     pkg = rpmbuild.build(specfile=specfile, defines=defines, top=top)
     shutil.move(pkg, config.get('output', './'))
+    return os.path.join(config.get('output', './'), os.path.basename(pkg))
 
 
 def main():
@@ -185,7 +186,9 @@ def main():
 
     try:
 
-        return build(source=path, config=config)
+        pkg = build(source=path, config=config)
+        sys.stdout.write('Package created at {0}.'.format(pkg))
+        sys.exit(0)
 
     except rpmbuild.RpmProcessError as exc:
 

--- a/rpmvenv/render.py
+++ b/rpmvenv/render.py
@@ -19,8 +19,11 @@ def macros(template, **kwargs):
         template: A jinja2 template to render with macro values.
 
     Keyword Args:
-        pkg_name: The name of the RPM package. (Required)
+        pkg_name: The name of the direcotory containing the package content.
+            (Required)
         pkg_version: The version number to assign the RPM. (Required)
+        pkg_rpm_name: The name of the RPM package. The default is to use
+            the pkg_name macro.
         pkg_release: The number of times this version has been released.
             The default is 1.
         pkg_group: The RPM group in which the package belongs. The default is
@@ -56,6 +59,7 @@ def macros(template, **kwargs):
                 'Missing required macro value {0}.'.format(required_value)
             )
 
+    macro_values.setdefault('pkg_rpm_name', macro_values['pkg_name'])
     macro_values.setdefault('pkg_release', 1)
     macro_values.setdefault('pkg_summary', macro_values['pkg_name'])
     macro_values.setdefault('pkg_group', 'Applications/System')

--- a/rpmvenv/rpmbuild.py
+++ b/rpmvenv/rpmbuild.py
@@ -66,17 +66,18 @@ def write_spec(top, spec):
     return path
 
 
-def copy_source(top, source):
+def copy_source(top, source, name=None):
     """Copy the source directory into the SOURCES directory.
 
     Args:
         top: The absolute path to the %_topdir.
         source: The absolute path to the source directory.
+        name: The name of the directory to place in SOURCES.
 
     Returns:
         The absolute path to the copy.
     """
-    name = os.path.basename(source)
+    name = name or os.path.basename(source)
     path = os.path.join(top, 'SOURCES', name)
     shutil.copytree(
         source,

--- a/rpmvenv/templates/rpm.spec
+++ b/rpmvenv/templates/rpm.spec
@@ -1,5 +1,6 @@
 ######### Custom Defined Macros ##########
 # pkg_name - The name of the source Python package. (%{pkg_name})
+# pkg_rpm_name - The name of the RPM. (%{pkg_rpm_name})
 # pkg_version - The version number to assign the RPM. (%{pkg_version})
 # pkg_release - The release number to assign the RPM. (%{pkg_release})
 # pkg_summary - The short summary of the package. (%{pkg_summary})
@@ -12,7 +13,7 @@
 # pkg_user_group - The grou which will own the installed files. (%{pkg_user_group})
 ###########################################
 
-%define final_installation_dir %{pkg_install_dir}/%{name}
+%define final_installation_dir %{pkg_install_dir}/%{pkg_name}
 %define venv_dir %{buildroot}/%{final_installation_dir}
 %define venv_bin %{venv_dir}/bin
 %define venv_python %{venv_bin}/python
@@ -26,7 +27,7 @@
 AutoReq: No
 AutoProv: No
 
-Name: %{pkg_name}
+Name: %{pkg_rpm_name}
 Version: %{pkg_version}
 Release:    %{pkg_release}
 Summary: %{pkg_summary}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='rpmvenv',
-    version='0.3.2',
+    version='0.4.0',
     url='https://github.com/kevinconway/rpmvenv',
     description='RPM packager for Python virtualenv.',
     author="Kevin Conway",

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -10,4 +10,5 @@ from rpmvenv import cmd
 
 def test_cmd_build(source_code, config_file):
     """Test that a default build works without exception."""
-    cmd.build(source_code, config_file)
+    pkg = cmd.build(source_code, config_file)
+    assert config_file['macros']['pkg_rpm_name'] in pkg


### PR DESCRIPTION
This name is distinct from the installation directory name and a
new option is added to handle the distinction.

Tests are updated to account for the change.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>