### PR TITLE
Fix bug related to deeply nested virtualenv

### DIFF
--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -61,7 +61,7 @@ class Extension(interface.Extension):
     @staticmethod
     def generate(namespace):
         """Generate Python virtualenv blocks and macros."""
-        venv_pip = '%{{venv_bin}}/pip install {0}'.format(
+        venv_pip = '%{{venv_python}} %{{venv_bin}}/pip install {0}'.format(
             ' '.join(namespace.pip_flags if namespace.pip_flags else ()),
         )
         venv_cmd = '{0} {1}'.format(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='rpmvenv',
-    version='0.6.0',
+    version='0.6.1',
     url='https://github.com/kevinconway/rpmvenv',
     description='RPM packager for Python virtualenv.',
     author="Kevin Conway",


### PR DESCRIPTION
Pip is unable to function as a standalone script when the shebang
header exceeds the maximum character length. Call the venv python
to execute pip resolves this issue.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>