### PR TITLE
Fixing a missing key in the example config.json and adding a comment that 'rpmbuild' is required.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,12 @@ content. Change the values where appropriate.
 .. code-block:: javascript
 
     {
-        "extensions": [
-            "python_venv",
-            "blocks"
-        ],
+        "extensions": {
+            "enabled": [
+                "python_venv",
+                "blocks"
+            ]
+        },
         "core": {
             "group": "Application/System",
             "license": "MIT",

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ content. Change the values where appropriate.
         }
     }
 
+Make sure `rpmbuild <http://www.rpm.org>`_ is installed.
 With the configuration file in place run the command line tool installed with
 the package to generate the RPM.
 


### PR DESCRIPTION
Hi,

Could be seen as an issue: Took me a while to figure out that *confpy* requires a dict and therefore you'd probably expect the 'enabled' key in "extensions": {"enabled" .. in the config.json file.

BTW, thanks for this very helpful tool!