### PR TITLE
replace pushd and popd with cd

### DIFF
--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -117,9 +117,9 @@ class Extension(interface.Extension):
             )
 
         spec.blocks.install.extend((
-            'pushd %{SOURCE0}',
+            'cd %{SOURCE0}',
             '%{venv_python} setup.py install',
-            'popd',
+            'cd -',
             '# RECORD files are used by wheels for checksum. They contain path'
             ' names which',
             '# match the buildroot and must be removed or the package will '


### PR DESCRIPTION
`cd` and `cd -` are [POSIX](http://pubs.opengroup.org/stage7tc1/utilities/cd.html) and should fulfil the same purpose here.

I encountered an `/bin/sh: pushd: not found` error on a vanilla ubuntu.

An alternative could be to change the `#!/bin/sh` on top of the generated file to `#!/bin/bash`.