### PR TITLE
Fix issue with passing relative paths as source

### DIFF
--- a/rpmvenv/cli.py
+++ b/rpmvenv/cli.py
@@ -61,7 +61,11 @@ def parse_args(argv):
     args, _ = parser.parse_known_args(argv)
     args = vars(args)
     args['config'] = os.path.abspath(args['config'])
-    args['source'] = args['source'] or os.path.dirname(args['config'])
+    args['source'] = (
+        os.path.abspath(args['source'])
+        if args['source']
+        else os.path.dirname(args['config'])
+    )
     return args
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r') as readmefile:
 
 setup(
     name='rpmvenv',
-    version='0.9.0',
+    version='0.9.1',
     url='https://github.com/kevinconway/rpmvenv',
     description='RPM packager for Python virtualenv.',
     author="Kevin Conway",


### PR DESCRIPTION
If the --source option is not an absolute path it breaks the copy
call used to move the source into the build directory. This patch
adds a call to normalize the path with abspath.

Signed-off-by: Kevin Conway <kevinjacobconway@gmail.com>