### PR TITLE
Keep user specified order of extensions into account when processing.

### DIFF
--- a/rpmvenv/extensions/loader.py
+++ b/rpmvenv/extensions/loader.py
@@ -21,10 +21,11 @@ class InvalidDependency(Exception):
 
 def load_extensions(whitelist=()):
     """Get an iterable of extensions in order."""
-    whitelist = tuple(set(('core',) + tuple(whitelist)))
+    whitelist = tuple(('core',) + tuple(whitelist))
+    unique_whitelist = tuple(set(whitelist))
     extensions = pkg_resources.iter_entry_points('rpmvenv.extensions')
     extensions = (
-        extension for extension in extensions if extension.name in whitelist
+        extension for extension in extensions if extension.name in unique_whitelist
     )
     extensions = tuple(set(extensions))
     extensions = sorted(extensions, key=lambda ext: whitelist.index(ext.name))

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -108,18 +108,23 @@ class Extension(interface.Extension):
         spec.blocks.files.append('/%{venv_install_dir}')
 
         spec.blocks.install.append('%{venv_cmd} %{venv_dir}')
-        for requirement in config.python_venv.requirements:
-
-            spec.blocks.install.append(
-                '%{{venv_pip}} -r %{{SOURCE0}}/{0}'.format(
-                    requirement,
+        # If we have requirements files, install based on them.
+        if len(tuple(config.python_venv.requirements)) > 0:
+            for requirement in config.python_venv.requirements:
+                spec.blocks.install.append(
+                    '%{{venv_pip}} -r %{{SOURCE0}}/{0}'.format(
+                        requirement,
+                    )
                 )
-            )
+        # Otherwise, use standard Python install.
+        else:
+            spec.blocks.install.extend((
+                'cd %{SOURCE0}',
+                '%{venv_python} setup.py install',
+                'cd -',
+            ))
 
         spec.blocks.install.extend((
-            'cd %{SOURCE0}',
-            '%{venv_python} setup.py install',
-            'cd -',
             '# RECORD files are used by wheels for checksum. They contain path'
             ' names which',
             '# match the buildroot and must be removed or the package will '


### PR DESCRIPTION
When using both the blocks extension and the python_venv extension, my extra commands specified in the blocks extension would randomly appear either before or after the commands from python_venv based on the hash present in the set commands used. I required them to be after python_venv consistently. This commit processes them according to the order the extensions are specified in the config file so the user has definite control over the orders.

A nice improvement to blocks would allow specification of whether the additional commands should be appended or prepended to everything else being added.
