### PR TITLE
Release shouldn't be limited to integers only.

### DIFF
--- a/rpmvenv/extensions/core.py
+++ b/rpmvenv/extensions/core.py
@@ -25,8 +25,8 @@ cfg = Configuration(
             required=True,
         ),
         release=StringOption(
-            description='The release number for the RPM. Default is 1%{?dist}',
-            default='1%{?dist}',
+            description='The release number for the RPM. Default is 1. Supports strings to let free usage of, for example, %{?dist}.',
+            default='1',
         ),
         summary=StringOption(
             description='The short package summary.',

--- a/rpmvenv/extensions/core.py
+++ b/rpmvenv/extensions/core.py
@@ -25,9 +25,9 @@ cfg = Configuration(
             description='The RPM version to build.',
             required=True,
         ),
-        release=IntegerOption(
-            description='The release number for the RPM. Default is 1.',
-            default=1,
+        release=StringOption(
+            description='The release number for the RPM. Default is 1%{?dist}',
+            default='1%{?dist}',
         ),
         summary=StringOption(
             description='The short package summary.',

--- a/rpmvenv/extensions/core.py
+++ b/rpmvenv/extensions/core.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from confpy.api import Configuration
-from confpy.api import IntegerOption
 from confpy.api import Namespace
 from confpy.api import StringOption
 from confpy.api import ListOption


### PR DESCRIPTION
Release can be more than an integer, for example if you want to follow the good practice of automatically adding the distribution (i.e.: el5, el6, el7) using %{?dist}.