### PR TITLE
Use a tmpdir for CLI test RPM output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,25 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import tempfile
+
 import pytest
 
 from rpmvenv import cli
+
+out_dir = None
+
+
+@pytest.fixture(scope='function', autouse=True)
+def create_tmpdir(request):
+    global out_dir
+    out_dir = tempfile.mkdtemp(suffix='rpmvenv')
+
+    def delete_tmpdir():
+        import shutil
+        shutil.rmtree(out_dir)
+
+    request.addfinalizer(delete_tmpdir)
 
 
 @pytest.mark.skipif(
@@ -17,7 +33,10 @@ from rpmvenv import cli
 def test_python_cmd_build(python_source_code, python_config_file):
     """Test that a default build works without exception."""
     with pytest.raises(SystemExit) as exc_info:
-        cli.main((python_config_file, '--source', python_source_code))
+        cli.main((python_config_file,
+                  '--source', python_source_code,
+                  '--destination', out_dir,
+                  ))
     rc = exc_info.value.code if type(exc_info.value) == SystemExit else \
         exc_info.value
     assert rc == 0


### PR DESCRIPTION
This ensures the tests can be run multiple times without having to
manually delete the test RPM they generate, which is helpful when
developing locally.

It also avoids polluting the repo with test files.
