### PR TITLE
Allow customization of additional files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,14 +154,29 @@ This extension will allow for packaging any files even if they are not a part
 of the built project. This extension is enabled by adding "file_extras" in the
 list of enabled extensions. This extension also requires that
 'file_permissions' be enabled. It uses the same user and group to assign
-ownership of the extra files.
+ownership of the extra files. Source paths are relative to the root.
 
 .. code-block:: javascript
 
     {"file_extras": {
-        // A list of source:destination pairs relative to the root.
         "files": [
-            'somedir/project_init_script:etc/init.d/project'
+            {
+                "src": "somedir/project_init_script",
+                "dest": "etc/init.d/project",
+            },
+            {
+                "src": "somedir/readme",
+                "dest": "usr/share/doc/project/readme",
+                "doc": true
+            },
+            {
+                "src": "somedir/project.conf",
+                "dest": "etc/project.conf",
+                // valid options include true, "noreplace", and "missingok"
+                "config": "noreplace"
+            },
+            // source:destination pairs (deprecated)
+            "somedir/project_init_script:etc/init.d/project"
         ]
     }}
 
@@ -295,3 +310,4 @@ a summary::
 
     You give us the rights to maintain and distribute your code and we promise
     to maintain an open source distribution of anything you contribute.
+

--- a/rpmvenv/extensions/files/extras.py
+++ b/rpmvenv/extensions/files/extras.py
@@ -1,4 +1,4 @@
-"""Extensions which package files not typically in the buildroot."""
+"""Extension which packages files not typically in the buildroot."""
 
 from __future__ import division
 from __future__ import absolute_import
@@ -8,17 +8,18 @@ from __future__ import unicode_literals
 from confpy.api import Configuration
 from confpy.api import ListOption
 from confpy.api import Namespace
-from confpy.api import PatternOption
 
+from .option import FileOption
 from .. import interface
 
 
 cfg = Configuration(
     file_extras=Namespace(
-        description='Add default file permissions to files in buildroot.',
+        description='Package files not in the Python package.',
         files=ListOption(
-            description='Files to move as src:dest. Relative to the root.',
-            option=PatternOption(pattern='.*:.*'),
+            description='Extra files to include. Paths are relative to'
+                        'buildroot.',
+            option=FileOption(),
             default=(),
         ),
     ),
@@ -31,31 +32,47 @@ class Extension(interface.Extension):
 
     name = 'file_extras'
     description = 'Package files not in the buildroot.'
-    version = '1.0.0'
+    version = '1.1.0'
     requirements = {
         'file_permissions': ('>=1.0.0', '<2.0.0'),
     }
 
     @staticmethod
     def generate(config, spec):
-        """Produce file block segments for setting permissions."""
+        """Produce file block segments for packaging files."""
         for file_ in config.file_extras.files:
 
-            src, dest = file_.split(':')
+            if file_.file_type is not None:
+                if file_.file_type_option is not None:
+                    # file with a modifier (e.g. config) including an option
+                    # (e.g. noreplace)
+                    file_directive = '%{1}({2}) /{0}'.format(
+                        file_.dest,
+                        file_.file_type,
+                        file_.file_type_option
+                    )
+                else:
+                    # file with a modifier (e.g. doc) but no additional option
+                    file_directive = '%{1} /{0}'.format(file_.dest,
+                                                        file_.file_type)
+            else:
+                # simple file without an extra modifiers
+                file_directive = '/{0}'.format(file_.dest)
+
             spec.blocks.install.append(
-                'mkdir -p "%{{buildroot}}/%(dirname {0})"'.format(dest)
+                'mkdir -p "%{{buildroot}}/%(dirname {0})"'.format(file_.dest)
             )
             spec.blocks.install.append(
                 'cp -R %{{SOURCE0}}/{0} %{{buildroot}}/{1}'.format(
-                    src,
-                    dest,
+                    file_.src,
+                    file_.dest,
                 )
             )
-            spec.blocks.files.append('/{0}'.format(dest))
+            spec.blocks.files.append(file_directive)
             spec.blocks.post.append(
                 'chown -R '
                 '%{{file_permissions_user}}:%{{file_permissions_group}} '
-                '/{0}'.format(dest)
+                '/{0}'.format(file_.dest)
             )
 
         return spec

--- a/rpmvenv/extensions/files/option.py
+++ b/rpmvenv/extensions/files/option.py
@@ -1,0 +1,64 @@
+from collections import MutableMapping, namedtuple
+
+from confpy.core import option
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
+RpmFile = namedtuple('RpmFile',
+                     ['src', 'dest', 'file_type', 'file_type_option'])
+
+
+class FileOption(option.Option):
+    def coerce(self, value):
+        """Convert dict or string values into RpmFile values.
+
+        Supports structured dicts for more advanced directives or simple
+        colon delimited strings for basic files.
+
+        Args:
+            value (str or dict): The value to coerce.
+
+        Raises:
+            TypeError: If the value is not a dict or string.
+            ValueError: For dicts, if the value is missing a required key.
+                        For strings, if the value is missing a colon.
+
+        Returns:
+            RpmFile: The RpmFile value represented.
+        """
+        if isinstance(value, MutableMapping):
+            if 'src' not in value:
+                raise ValueError('The value is missing the "src" key')
+            if 'dest' not in value:
+                raise ValueError('The value is missing the "dest" key')
+
+            file_type = None
+            file_type_option = None
+
+            config_type = value.get('config', False)
+            if config_type:
+                file_type = 'config'
+                if isinstance(config_type, basestring):
+                    file_type_option = config_type
+            elif value.get('doc', False):
+                file_type = 'doc'
+
+            return RpmFile(src=value['src'],
+                           dest=value['dest'],
+                           file_type=file_type,
+                           file_type_option=file_type_option)
+
+        elif isinstance(value, basestring):
+            try:
+                src, dest = value.split(':')
+                return RpmFile(src=src,
+                               dest=dest,
+                               file_type=None,
+                               file_type_option=None)
+            except ValueError:
+                raise ValueError('The value {0} is missing a :'.format(value))
+
+        raise TypeError('Could not coerce {0} to an RpmFile'.format(value))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def python_source_code(python_git_url, tmpdir):
 @pytest.fixture
 def python_config_file(python, tmpdir):
     """Get a config file path."""
+    extra_filename = 'README.rst'
     json_file = str(tmpdir.join('conf.json'))
     config_body = {
         "extensions": {
@@ -68,6 +69,7 @@ def python_config_file(python, tmpdir):
                 "description_text",
                 "python_venv",
                 "file_permissions",
+                "file_extras",
                 "blocks",
             ],
         },
@@ -83,6 +85,36 @@ def python_config_file(python, tmpdir):
         "file_permissions": {
             "group": "vagrant",
             "user": "vagrant",
+        },
+        "file_extras": {
+            "files": [
+                extra_filename + ":opt/test-pkg/" + extra_filename + "1",
+                {
+                    "src": extra_filename,
+                    "dest": "opt/test-pkg/" + extra_filename + "2"
+                },
+                {
+                    "src": extra_filename,
+                    "dest": "opt/test-pkg/" + extra_filename + "3",
+                    "config": True
+                },
+                {
+                    "src": extra_filename,
+                    "dest": "opt/test-pkg/" + extra_filename + "4",
+                    "config": "noreplace"
+                },
+                {
+                    "src": extra_filename,
+                    "dest": "opt/test-pkg/" + extra_filename + "5",
+                    "doc": True
+                },
+                {
+                    "src": extra_filename,
+                    "dest": "opt/test-pkg/" + extra_filename + "6",
+                    "doc": False,
+                    "config": False
+                }
+            ]
         },
         "python_venv": {
             "cmd": "virtualenv",

--- a/tests/test_fileoption.py
+++ b/tests/test_fileoption.py
@@ -1,0 +1,126 @@
+"""Test suites for the FileOption object."""
+
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pytest
+
+from rpmvenv.extensions.files import option as file_opt
+
+
+def test_parse_colon_delimited():
+    parser = file_opt.FileOption()
+
+    src = '/foo/bar'
+    dest = '/etc/foo'
+
+    rpm_file = parser.coerce('{0}:{1}'.format(src, dest))
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == src
+    assert rpm_file.dest == dest
+    assert rpm_file.file_type is None
+    assert rpm_file.file_type_option is None
+
+
+def test_parse_colon_delimited_invalid():
+    parser = file_opt.FileOption()
+
+    with pytest.raises(ValueError) as excinfo:
+        parser.coerce('foobar')
+    assert 'foobar' in str(excinfo.value)
+
+
+def test_parse_dict_no_file_type():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo'
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type is None
+    assert rpm_file.file_type_option is None
+
+
+def test_parse_dict_no_file_type_explicit():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo',
+        'config': 0,
+        'doc': False
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type is None
+    assert rpm_file.file_type_option is None
+
+
+def test_parse_dict_doc_file():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo',
+        'doc': 'foobar'  # anything truthy is okay, value is ignored
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type == 'doc'
+    assert rpm_file.file_type_option is None
+
+
+def test_parse_dict_config_file_no_option():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo',
+        'config': True
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type == 'config'
+    assert rpm_file.file_type_option is None
+
+
+def test_parse_dict_config_file_with_option():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo',
+        'config': 'noreplace'
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type == 'config'
+    assert rpm_file.file_type_option == 'noreplace'
+
+
+def test_parse_unknown():
+    parser = file_opt.FileOption()
+
+    value = object()
+
+    with pytest.raises(TypeError):
+        parser.coerce(value)


### PR DESCRIPTION
Support for more advanced files (e.g. docs and config) is provided
via the "file_extras" plugin.

For simple file copies and backwards compatibility, colon-delimited
values are still supported.

Additionally, a `dict` format is supported. The required keys are
`src` and `dest` which behave the same as in the legacy syntax. To
mark a file as a configuration file, the `config` key should be `True`.
The same applies for documentation files (with the key `doc`).

If the value for the `config` key is a string, this will be used to
further customize the directive. This is typically used with
`noreplace` or `missingok`, which will produce `%config(noreplace)` and
`%config(missingok)` respectively.

Example configuration (JSON):
```json
{
  "file_extras": {
    "files": [
      "bar:opt/foo/bar",
      {
        "src": "readme.txt",
        "dest": "usr/share/doc/foobar/readme.txt",
        "doc": true
      },
      {
        "src": "app.conf",
        "dest": "etc/foobar/app.conf",
        "config": "noreplace"
      }
    ]
  }
}
```

This addresses #28.