### PR TITLE
Added: Optional symlink argument.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ target/
 
 # IntelliJ / PyCharm
 *.iml
+.idea
 
 # Vim
 *.swp

--- a/rpmvenv/cli.py
+++ b/rpmvenv/cli.py
@@ -58,6 +58,12 @@ def parse_args(argv):
         default=False,
         action='store_true',
     )
+    parser.add_argument(
+        '--symlink',
+        help='Represent symlinks as symlinks instead of copying the file. Default is False',
+        default=False,
+        action='store_true',
+    )
     args, _ = parser.parse_known_args(argv)
     args = vars(args)
     args['config'] = os.path.abspath(args['config'])
@@ -69,10 +75,10 @@ def parse_args(argv):
     return args
 
 
-def generate_rpm(source, destination, specfile, verbose=False):
+def generate_rpm(source, destination, specfile, verbose=False, symlink=False):
     """Generate an RPM from the given arguments mapping."""
     top = rpmbuild.topdir()
-    rpmbuild.copy_source(top, source)
+    rpmbuild.copy_source(top, source, symlink)
     specfile = rpmbuild.write_spec(top, specfile)
     pkg = rpmbuild.build(specfile=specfile, top=top, verbose=verbose)
     shutil.move(pkg, destination)
@@ -140,6 +146,7 @@ def main(argv=sys.argv[1:]):
             args['destination'],
             specfile,
             args['verbose'],
+            args['symlink'],
         )
 
     except rpmbuild.RpmProcessError as exc:

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -23,7 +23,7 @@ cfg = Configuration(
         flags=ListOption(
             description='Flags to pass to the venv during creation.',
             option=StringOption(),
-            default=(),
+            default=('--always-copy',),
         ),
         name=StringOption(
             description='The name of the installed venv.',

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -23,7 +23,7 @@ cfg = Configuration(
         flags=ListOption(
             description='Flags to pass to the venv during creation.',
             option=StringOption(),
-            default=('--always-copy',),
+            default=(),
         ),
         name=StringOption(
             description='The name of the installed venv.',

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -109,6 +109,7 @@ class Extension(interface.Extension):
         spec.blocks.files.append('/%{venv_install_dir}')
 
         spec.blocks.install.append('%{venv_cmd} %{venv_dir}')
+        spec.blocks.install.append('cd %{SOURCE0}')
         for requirement in config.python_venv.requirements:
 
             spec.blocks.install.append(
@@ -132,7 +133,9 @@ class Extension(interface.Extension):
             ' --destination=/%{venv_install_dir}',
             '# Strip native modules as they contain buildroot paths in their'
             ' debug information',
-            'find %{venv_dir}/lib -type f -name "*.so" | xargs -r strip'
+            'find %{venv_dir}/lib -type f -name "*.so" | xargs -r strip',
+            '# Remove symlink directories (lib64 -> lib)',
+            'for link in `find %{venv_dir} -type l` ; do source=`readlink $link` ; unlink $link ; cp -r $source $link ; done'
 
         ))
 

--- a/rpmvenv/rpmbuild.py
+++ b/rpmvenv/rpmbuild.py
@@ -67,7 +67,7 @@ def write_spec(top, spec):
     return path
 
 
-def copy_source(top, source, name=None):
+def copy_source(top, source, symlink, name=None):
     """Copy the source directory into the SOURCES directory.
 
     Args:
@@ -84,6 +84,7 @@ def copy_source(top, source, name=None):
         source,
         path,
         ignore=shutil.ignore_patterns(*IGNORED_PATTERNS),
+        symlinks=symlink,
     )
     return path
 


### PR DESCRIPTION
Added optional symlink argument. shutil.copytree doesn't follow symbolic links by default, this causes rpmvenv to exit when they are used.