### PR TITLE
Add obsoletes and conflicts core config options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,10 @@ for interacting with all the required RPM SPEC file tags like "Version" or
         "buildroot": "%(mktemp -ud %{_tmppath}/%{SOURCE0}-%{version}-%{release}-XXXXXX)",
         // System dependencies.
         "requires": [],
+        // Conflicting packages.
+        "conflicts": [],
+        // Packages to mark as obsolete.
+        "obsoletes": [],
         // Virtual packages satisfied by this RPM.
         "provides": []
     }}

--- a/rpmvenv/extensions/core.py
+++ b/rpmvenv/extensions/core.py
@@ -68,6 +68,18 @@ cfg = Configuration(
             description='Dependencies',
             required=False
         ),
+        conflicts=ListOption(
+            option=StringOption(),
+            default=(),
+            description='Conflicts',
+            required=False
+        ),
+        obsoletes=ListOption(
+            option=StringOption(),
+            default=(),
+            description='Obsoletes',
+            required=False
+        ),
         provides=ListOption(
             option=StringOption(),
             default=(),
@@ -101,6 +113,8 @@ class Extension(interface.Extension):
         buildroot = config.core.buildroot
         buildarch = config.core.buildarch
         requires = tuple(config.core.requires)
+        conflicts = tuple(config.core.conflicts)
+        obsoletes = tuple(config.core.obsoletes)
         provides = tuple(config.core.provides)
 
         spec.tags['Name'] = name
@@ -110,6 +124,12 @@ class Extension(interface.Extension):
 
         if requires:
             spec.tags['Requires'] = ', '.join(requires)
+
+        if conflicts:
+            spec.tags['Conflicts'] = ', '.join(conflicts)
+
+        if obsoletes:
+            spec.tags['Obsoletes'] = ', '.join(obsoletes)
 
         if provides:
             spec.tags['Provides'] = ', '.join(provides)


### PR DESCRIPTION
This exposes the RPM SPEC file fields `Obsoletes` and `Conflicts` into the core extension of the rpmvenv configuration file.