### PR TITLE
Pin isort (pytest dep) to a py26 compat version

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+isort==4.2.15
 pep8
 pyflakes
 pylint


### PR DESCRIPTION
Any version beyond `4.2.15` is made to be incompatible with py26. This patch pins the project to `4.2.15` as we want to preserve py26 compatibility and support for now. 