### PR TITLE
Fix installing packages from relative paths in requirements.txt

### DIFF
--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -121,22 +121,21 @@ class Extension(interface.Extension):
 
         spec.blocks.files.append('/%{venv_install_dir}')
 
-        spec.blocks.install.extend((
-            '%{venv_cmd} %{venv_dir}',
-            'cd %{SOURCE0}',
-        ))
+        spec.blocks.install.append('%{venv_cmd} %{venv_dir}')
         for requirement in config.python_venv.requirements:
 
-            spec.blocks.install.append(
-                '%{{venv_pip}} -r {0}'.format(
-                    requirement,
-                )
-            )
+            spec.blocks.install.extend((
+                'cd %{SOURCE0}',
+                '%{{venv_pip}} -r {0}'.format(requirement),
+                'cd -',
+            ))
 
         if config.python_venv.require_setup_py:
-            spec.blocks.install.append(
-                '%{venv_python} setup.py install'
-            )
+            spec.blocks.install.extend((
+                'cd %{SOURCE0}',
+                '%{venv_python} setup.py install',
+                'cd -',
+            ))
 
         spec.blocks.install.extend((
             '# RECORD files are used by wheels for checksum. They contain path'

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -121,21 +121,22 @@ class Extension(interface.Extension):
 
         spec.blocks.files.append('/%{venv_install_dir}')
 
-        spec.blocks.install.append('%{venv_cmd} %{venv_dir}')
+        spec.blocks.install.extend((
+            '%{venv_cmd} %{venv_dir}',
+            'cd %{SOURCE0}',
+        ))
         for requirement in config.python_venv.requirements:
 
             spec.blocks.install.append(
-                '%{{venv_pip}} -r %{{SOURCE0}}/{0}'.format(
+                '%{{venv_pip}} -r {0}'.format(
                     requirement,
                 )
             )
 
         if config.python_venv.require_setup_py:
-            spec.blocks.install.extend((
-                'cd %{SOURCE0}',
-                '%{venv_python} setup.py install',
-                'cd -',
-            ))
+            spec.blocks.install.append(
+                '%{venv_python} setup.py install'
+            )
 
         spec.blocks.install.extend((
             '# RECORD files are used by wheels for checksum. They contain path'


### PR DESCRIPTION
In current version of `rpmvenv` installing packages from relative paths in `requirements.txt` is broken.

There are times when you need to build a project that has a git submodule which located inside project source directory. A natural way to do this is write that dependency in requirements.txt in form:

```
submodule/
```

According to [requirements file format](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format) it is a common thing.

But in current version of `rpmvenv` generated spec will be as follow: 
```
%install
%{venv_cmd} %{venv_dir}
%{venv_pip} -r %{SOURCE0}/requirements.txt
cd %{SOURCE0}
%{venv_python} setup.py install
```

And installing of `submodule` will be failed because current directory will not contain `submodule/` folder at that moment.

```
+ virtualenv --python=python3.6 /tmp/rpmvenv3ac8hlsk/BUILDROOT/project-1.0.0-1.x86_64//var/app/project
Already using interpreter /usr/bin/python3.6
Using base prefix '/usr'
New python executable in /tmp/rpmvenv3ac8hlsk/BUILDROOT/project-1.0.0-1.x86_64/var/app/project/bin/python3.6
Also creating executable in /tmp/rpmvenv3ac8hlsk/BUILDROOT/project-1.0.0-1.x86_64/var/app/project/bin/python
Installing setuptools, pip, wheel...done.
+ /tmp/rpmvenv3ac8hlsk/BUILDROOT/project-1.0.0-1.x86_64//var/app/project/bin/python /tmp/rpmvenv3ac8hlsk/BUILDROOT/project-1.0.0-1.x86_64//var/app/project/bin/pip install -r /tmp/rpmvenv3ac8hlsk/SOURCES/opt/requirements.txt
Invalid requirement: 'submodule/'
It looks like a path. Does it exist ?
error: Bad exit status from /var/tmp/rpm-tmp.fFyJwu (%install)


RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.fFyJwu (%install)
There was an error generating the RPM.
The exit code was: 1.
The rpmbuild command was: rpmbuild -ba --define='_topdir /tmp/rpmvenv3ac8hlsk' /tmp/rpmvenv3ac8hlsk/SOURCES/package.spec.
```

 I was fixed this and spec will be in the next form now:
```
%install
%{venv_cmd} %{venv_dir}
cd %{SOURCE0}
%{venv_pip} -r requirements.txt
%{venv_python} setup.py install
```