### PR TITLE
Add use_pip_install option for venv. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,11 @@ enabled by adding 'python_venv' to the list of enabled extensions.
         // Flags to pass to pip during pip install calls.
         "pip_flags": "--index-url https://internal-pypi-server.org",
         // Optional flag to enable, disable binary striping. Default is true if not present.
-        "strip_binaries": true
+        "strip_binaries": true,
+        // Optional flag to install the distribution into the venv with
+        // pip install, rather than setup.py install. Default is false if
+        // not present.
+        "use_pip_install": false,
     }}
 
 CLI Flags And Environment Variables
@@ -335,4 +339,3 @@ a summary::
 
     You give us the rights to maintain and distribute your code and we promise
     to maintain an open source distribution of anything you contribute.
-

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -59,7 +59,13 @@ cfg = Configuration(
                         'that often contains the buildroot paths',
             required=False,
             default=True,
-        )
+        ),
+        use_pip_install=BoolOption(
+            description='Whether to use pip install to install the package '
+                        'in the venv',
+            required=False,
+            default=False,
+        ),
     ),
 )
 
@@ -131,11 +137,14 @@ class Extension(interface.Extension):
             ))
 
         if config.python_venv.require_setup_py:
-            spec.blocks.install.extend((
-                'cd %{SOURCE0}',
-                '%{venv_python} setup.py install',
-                'cd -',
-            ))
+            spec.blocks.install.append('cd %{SOURCE0}')
+
+            if config.python_venv.use_pip_install:
+                spec.blocks.install.append('%{venv_pip} .')
+            else:
+                spec.blocks.install.append('%{venv_python} setup.py install')
+
+            spec.blocks.install.append('cd -')
 
         spec.blocks.install.extend((
             '# RECORD files are used by wheels for checksum. They contain path'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,13 @@ def pytest_generate_tests(metafunc):
 
     if 'skip_binary_strip' in metafunc.fixturenames:
         metafunc.parametrize(
-                'skip_binary_strip',
-                (metafunc.config.option.skip_binary_strip,)
+            'skip_binary_strip',
+            (metafunc.config.option.skip_binary_strip,)
+        )
+
+    if 'use_pip_install' in metafunc.fixturenames:
+        metafunc.parametrize(
+            'use_pip_install', (True, False)
         )
 
 
@@ -82,7 +87,7 @@ def qa_skip_buildroot(skip_binary_strip):
 
 
 @pytest.fixture
-def python_config_file(python, skip_binary_strip, tmpdir):
+def python_config_file(python, skip_binary_strip, use_pip_install, tmpdir):
     """Get a config file path."""
     extra_filename = 'README.rst'
     json_file = str(tmpdir.join('conf.json'))
@@ -145,6 +150,7 @@ def python_config_file(python, skip_binary_strip, tmpdir):
             "path": "/usr/share/python",
             "python": python,
             "strip_binaries": not skip_binary_strip,
+            "use_pip_install": use_pip_install,
         },
         "blocks": {
             "post": ("echo 'Hello'",),

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -1,0 +1,28 @@
+"""Test suites for the python venv Extension."""
+
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import copy
+
+from rpmvenv.spec import Spec
+from rpmvenv.extensions.python import venv
+
+
+def test_use_pip_install_off():
+    ext = venv.Extension()
+    config = copy.deepcopy(venv.cfg)
+    spec = Spec()
+    ext.generate(config, spec)
+    assert '%{venv_python} setup.py install' in str(spec)
+
+
+def test_use_pip_install_on():
+    ext = venv.Extension()
+    config = copy.deepcopy(venv.cfg)
+    config.python_venv.use_pip_install = True
+    spec = Spec()
+    ext.generate(config, spec)
+    assert '%{venv_pip} .' in str(spec)


### PR DESCRIPTION
This installs the application with `pip install .` rather than `python setup.py install` (which installs the application as an egg).