### PR TITLE
Travis build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,40 @@
 language: python
+
 sudo: false
+
 python:
     - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
+    - "3.6"
+
 env:
     - NO_STRIP=1
     - NO_STRIP=0
+
+matrix:
+    include:
+        - python: "3.7"
+          dist: xenial
+          env: NO_STRIP=0
+        - python: "3.7"
+          dist: xenial
+          env: NO_STRIP=1
+
 addons:
     apt:
         packages:
         - rpm
         - enchant
+
 install:
     - if [[ "$(python --version 2>&1)" =~ Python\ (2\.*) ]]; then pip install -U jinja2; else echo "Skipping JINJA2 for $(python --version 2>&1)."; fi
     - pip install -rtest-requirements.txt
     - pip install -e ./
+
 script:
-    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[3-4].*) ]]; then pep8 rpmvenv/; else echo "Skipping PEP8 for $(python --version 2>&1)."; fi
-    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[3-4].*) ]]; then pyflakes rpmvenv/; else echo "Skipping PyFlakes for $(python --version 2>&1)."; fi
-    - if [[ "${NO_STRIP}" == "1" ]]; then py.test --skip-binary-strip --python-git-url="https://github.com/kevinconway/rpmvenv_manylinux_issue.git" tests/; else py.test tests/; fi
+    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[4-7].*) ]]; then pep8 rpmvenv/; else echo "Skipping PEP8 for $(python --version 2>&1)."; fi
+    - if [[ "$(python --version 2>&1)" =~ Python\ (2\.7.*|3\.[4-7].*) ]]; then pyflakes rpmvenv/; else echo "Skipping PyFlakes for $(python --version 2>&1)."; fi
+    - if [[ "${NO_STRIP}" == "1" ]]; then py.test -v --skip-binary-strip --python-git-url="https://github.com/kevinconway/rpmvenv_manylinux_issue.git" tests/; else py.test -v tests/; fi

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 isort==4.2.15
 pep8
-pyflakes; python_version=='2.7' or python_version=='3.4' or python_version=='3.5' or python_version=='3.6'
+pyflakes; python_version=='2.7' or python_version>='3.4'
 pylint; python_version>='3.4'
 pytest
 pyenchant

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 isort==4.2.15
 pep8
-pyflakes
-pylint
+pyflakes; python_version=='2.7' or python_version=='3.4' or python_version=='3.5' or python_version=='3.6'
+pylint; python_version>='3.4'
 pytest
 pyenchant


### PR DESCRIPTION
- Add 3.5, 3.6 and 3.7 (which requires xenial)
- Don't install pyflakes on 2.6 or 3.3
- Only install pylint on >= 2.7
- Add -v to pytest to see which fixtures are being used 