### PR TITLE
Remove pycache from venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     include:
         - python: "3.7"
           dist: xenial
+        - python: "3.8"
+          dist: xenial
 addons:
     apt:
         packages:

--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,9 @@ enabled by adding 'python_venv' to the list of enabled extensions.
         // pip install, rather than setup.py install. Default is false if
         // not present.
         "use_pip_install": false,
+        // Optional flag to remove compiled bytecode from venv.
+        // It will reduce size of resulting package. Default is false if not present.
+        "remove_pycache": false,
     }}
 
 CLI Flags And Environment Variables

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -145,6 +145,7 @@ class Extension(interface.Extension):
                 spec.blocks.install.append('%{venv_python} setup.py install')
 
             spec.blocks.install.append('cd -')
+        spec.blocks.install.append(r'find %{venv_dir} -type d -name "__pycache__" -print0 | xargs -0 rm -r')
 
         spec.blocks.install.extend((
             '# RECORD files are used by wheels for checksum. They contain path'

--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -66,6 +66,12 @@ cfg = Configuration(
             required=False,
             default=False,
         ),
+        remove_pycache=BoolOption(
+            description='Whether to remove compiled bytecode to reduce '
+                        'package size.',
+            required=False,
+            default=False,
+        ),
     ),
 )
 
@@ -145,7 +151,12 @@ class Extension(interface.Extension):
                 spec.blocks.install.append('%{venv_python} setup.py install')
 
             spec.blocks.install.append('cd -')
-        spec.blocks.install.append(r'find %{venv_dir} -type d -name "__pycache__" -print0 | xargs -0 rm -r')
+
+        if config.python_venv.remove_pycache:
+            spec.blocks.install.append(
+                r'find %{venv_dir} -type d -name "__pycache__" -print0 | '
+                r'xargs -0 rm -rf'
+            )
 
         spec.blocks.install.extend((
             '# RECORD files are used by wheels for checksum. They contain path'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,11 @@ def pytest_generate_tests(metafunc):
             'use_pip_install', (True, False)
         )
 
+    if 'remove_pycache' in metafunc.fixturenames:
+        metafunc.parametrize(
+            'remove_pycache', (True, False)
+        )
+
 
 @pytest.fixture
 def python_source_code(python_git_url, tmpdir):
@@ -87,7 +92,7 @@ def qa_skip_buildroot(skip_binary_strip):
 
 
 @pytest.fixture
-def python_config_file(python, skip_binary_strip, use_pip_install, tmpdir):
+def python_config_file(python, skip_binary_strip, use_pip_install, remove_pycache, tmpdir):
     """Get a config file path."""
     extra_filename = 'README.rst'
     json_file = str(tmpdir.join('conf.json'))
@@ -151,6 +156,7 @@ def python_config_file(python, skip_binary_strip, use_pip_install, tmpdir):
             "python": python,
             "strip_binaries": not skip_binary_strip,
             "use_pip_install": use_pip_install,
+            "remove_pycache": remove_pycache
         },
         "blocks": {
             "post": ("echo 'Hello'",),

--- a/tests/test_venv.py
+++ b/tests/test_venv.py
@@ -26,3 +26,23 @@ def test_use_pip_install_on():
     spec = Spec()
     ext.generate(config, spec)
     assert '%{venv_pip} .' in str(spec)
+
+
+class TestRemovePycache:
+    cmd = r'find %{venv_dir} -type d -name "__pycache__" -print0 | xargs -0 rm -rf'
+
+    def test_remove_pycache_off(self):
+        ext = venv.Extension()
+        config = copy.deepcopy(venv.cfg)
+        spec = Spec()
+        ext.generate(config, spec)
+        assert self.cmd not in str(spec)
+
+    def test_remove_pycache_on(self):
+        ext = venv.Extension()
+        config = copy.deepcopy(venv.cfg)
+        config.python_venv.remove_pycache = True
+        spec = Spec()
+        ext.generate(config, spec)
+        assert self.cmd in str(spec)
+


### PR DESCRIPTION
It's possible to reduce size of resulting rpm package if remove compiled bytecode.