### PR TITLE
add Macro extension

### DIFF
--- a/rpmvenv/extensions/macros/__init__.py
+++ b/rpmvenv/extensions/macros/__init__.py
@@ -1,0 +1,6 @@
+"""Add custom macros to the spec file"""
+
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals

--- a/rpmvenv/extensions/macros/macros.py
+++ b/rpmvenv/extensions/macros/macros.py
@@ -1,0 +1,42 @@
+"""Extension for packaging a Python virtualenv."""
+
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from confpy.api import Configuration
+from confpy.api import ListOption
+from confpy.api import Namespace
+from confpy.api import StringOption
+from confpy.api import BoolOption
+
+from .. import interface
+
+
+cfg = Configuration(
+    macros=Namespace(
+        macros=ListOption(
+            description='Add global macros',
+            option=StringOption()
+        )
+    )
+)
+
+
+class Extension(interface.Extension):
+
+    """Extension for global macros"""
+
+    name = 'macros'
+    description = 'Packaging extension for global macros.'
+    version = '1.0.0'
+    requirements = {}
+
+    @staticmethod
+    def generate(config, spec):
+        """Generate Python virtualenv content."""
+        for line in config.macros.macros:
+            key, value = line.split(None, 1)
+            spec.macros[key] = value
+        return spec

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             'file_extras = rpmvenv.extensions.files.extras:Extension',
             'python_venv = rpmvenv.extensions.python.venv:Extension',
             'blocks = rpmvenv.extensions.blocks.generic:Extension',
+            'macros = rpmvenv.extensions.macros.macros:Extension',
         ]
     },
     package_data={


### PR DESCRIPTION
Hi,

I wanted to be able add custom `%define` lines to the top of the resulting spec file. I couldn't see an existing way to do this, so I created this proof-of-concept extension to add this functionality.

For example, this block:

```
{
    "macros": {
        "macros": [
            "__os_install_post %{nil}",
            "_build_id_links none"
        ]
    }
}
```

Causes this to be added to the spec file:
```
%define __os_install_post %{nil}         
%define _build_id_links none 
```

I realise this needs some tidying up before it could be merged. But wanted to get some early feedback on if this approach is sensible before continuing.

Ideally I wanted the configuration block to be in the following format:
```
{
    "macros": {
        "__os_install_post": "%{nil}",
        "_build_id_links": "none"
}
```

But I couldn't see a way of having arbitrary keys for a `confpy.api.Namespace` object. Hence why I ended up with the current ugly configuration format. Any advise on how to improve this would be welcome.
