### PR TITLE
Add semver version limit due to compat changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'argparse',
         'confpy',
         'ordereddict',
-        'semver',
+        'semver<2.10', # semver dropped support for legacy Python at 2.10.
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
The semver library stopped working for legacy Python versions after the
2.9.1 release. This adds a less than 2.10 restriction to the abstract
dependency requirements so that folks don't need to all add a pin to
their requirements.txt.