### PR TITLE
Fix issue with strip

### DIFF
--- a/rpmvenv/extensions/python/venv.py
+++ b/rpmvenv/extensions/python/venv.py
@@ -176,5 +176,8 @@ class Extension(interface.Extension):
                 'their debug information',
                 'find %{venv_dir}/lib -type f -name "*.so" | xargs -r strip',
             ))
+        else:
+            spec.macros["debug_package"] = "debug_package %{nil}"
+            spec.macros["__strip"] = "/bin/true"
 
         return spec


### PR DESCRIPTION
Fix issue with strip

The following is a proposed solution for fixing the following issue. 

## Current Behavior

While having the requirement of "opencv-python-headless", using the settings "strip_binaries": false
and QA_SKIP_BUILD_ROOT=1 and running "from cv2 import *" in the rpmvenv created venv you get the exception:

```text
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    from cv2 import * 
  File "//opt/issue/issue/lib64/python3.6/site-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
ImportError: //opt/issue/issue/lib64/python3.6/site-packages/cv2/cv2.cpython-36m-x86_64-linux-gnu.so: ELF load command address/offset not properly aligned
```

## Expected Behavior

Using "strip_binaries": false and QA_SKIP_BUILD_ROOT=1 should not strip any binaries.

## Possible Solution

While investigating the issue, it was found, that rpmbuild also calls strip and hence causes the above exception.
This proposed solution disables rpmbuild stripping altogether and only does stripping in rpmvenv if "strip_binaries": true.

## Steps to Reproduce

1. Create issue.json with content:

```json
{
  "extensions": {
    "enabled": [
      "python_venv",
      "blocks"
    ]
  },
  "core": {
    "name": "issue",
    "version": "0.1.0",
    "release": "1",
    "summary": "issue",
    "license": "proprietary",
    "requires": [
      "python36"
    ],
    "provides": [],
    "obsoletes": []
  },
  "python_venv": {
    "cmd": "virtualenv",
    "flags": [],
    "name": "issue",
    "path": "/opt/issue",
    "python": "python3.6",
    "require_setup_py": false,
    "requirements": [
      "issue-requirements.txt"
    ],
    "strip_binaries": false,
    "use_pip_install": true,
    "remove_pycache": true
  },
  "blocks": {
    "desc": [
      "this is an issue package"
    ]
  }
}
```

2. Create issue-requirements.txt with content:

```text
opencv-python-headless
```

3. Run `rpmvenv issue.json`

4. Run `sudo yum localinstall issue-0.1.0-1.x86_64.rpm`.

5. Active venv under /opt/issue/issue.

6. python -c "from cv2 import *"

## Context

OS: CentOS Linux 7 (Core)

rpmvenv: Version 0.23.0

Python: Version 3.6.8

rpmbuild: Version 4.11.3 (result of rpmbuild --version)
