### PR TITLE
Update venvctrl for nu shell support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: CI
 on:
   push:
     branches:
-      - 'master'
-    tags: [ '*' ]
+      - "master"
+    tags: ["*"]
   pull_request:
     branches:
-      - 'master'
+      - "master"
 
 jobs:
   lint:
@@ -26,7 +26,7 @@ jobs:
           key: pip-lint-${{ hashFiles('requirements.txt', 'test-requirements.txt') }}
           path: ~/.cache/pip
           restore-keys: |
-              pip-lint-
+            pip-lint-
       - name: Install dependencies
         run: |
           python -m pip install -r requirements.txt
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         pyver: ['2.7', '3.5', '3.6', '3.7']
+        pyver: ["2.7", "3.5", "3.6", "3.7"]
       fail-fast: true
     steps:
       - name: Install deps
@@ -62,10 +62,9 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.pyver }}-${{ hashFiles('test-requirements.txt') }}
           restore-keys: |
-              ${{ runner.os }}-pip-${{ matrix.pyver }}-
+            ${{ runner.os }}-pip-${{ matrix.pyver }}-
       - name: Install dependencies
         run: |
-          python -m pip install virtualenv==20.10.0
           if [[ "$(python --version 2>&1)" =~ Python\ (2\.*) ]]; then pip install -U jinja2; else echo "Skipping JINJA2 for $(python --version 2>&1)."; fi
           python -m pip install -r requirements.txt
           python -m pip install -r test-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jinja2==2.11.3
-venvctrl==0.4.2
-argparse==1.4.0
-confpy==0.11.0
-ordereddict==1.1
-semver==2.9.1
+venvctrl>=0.5.0,<2.0.0
+argparse>=1.4.0,<2.0.0
+confpy>=0.11.0,<2.0.0
+ordereddict>=1.1.0,<2.0.0
+semver>=2.9.1,<3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,45 +34,39 @@ def pytest_addoption(parser):
 
 
 def pytest_generate_tests(metafunc):
-    if 'python_git_url' in metafunc.fixturenames:
+    if "python_git_url" in metafunc.fixturenames:
         metafunc.parametrize(
-            'python_git_url',
-            (metafunc.config.option.python_git_url,)
+            "python_git_url", (metafunc.config.option.python_git_url,)
         )
 
-    if 'python' in metafunc.fixturenames:
-        metafunc.parametrize('python', (metafunc.config.option.python,))
+    if "python" in metafunc.fixturenames:
+        metafunc.parametrize("python", (metafunc.config.option.python,))
 
-    if 'skip_binary_strip' in metafunc.fixturenames:
+    if "skip_binary_strip" in metafunc.fixturenames:
         metafunc.parametrize(
-            'skip_binary_strip',
-            (metafunc.config.option.skip_binary_strip,)
+            "skip_binary_strip", (metafunc.config.option.skip_binary_strip,)
         )
 
-    if 'use_pip_install' in metafunc.fixturenames:
-        metafunc.parametrize(
-            'use_pip_install', (True, False)
-        )
+    if "use_pip_install" in metafunc.fixturenames:
+        metafunc.parametrize("use_pip_install", (True, False))
 
-    if 'remove_pycache' in metafunc.fixturenames:
-        metafunc.parametrize(
-            'remove_pycache', (True, False)
-        )
+    if "remove_pycache" in metafunc.fixturenames:
+        metafunc.parametrize("remove_pycache", (True, False))
 
 
 @pytest.fixture
 def python_source_code(python_git_url, tmpdir):
     """Generate a source code directory and return the path."""
     # Strip off the '.git' and grap the last URL segment.
-    pkg_name = python_git_url[:-4].split('/')[-1]
-    cmd = 'git clone {0} {1}/{2}'.format(
+    pkg_name = python_git_url[:-4].split("/")[-1]
+    cmd = "git clone {0} {1}/{2}".format(
         python_git_url,
         str(tmpdir),
         pkg_name,
-    ).encode('ascii')
+    ).encode("ascii")
     if sys.version_info[0] > 2:
 
-        cmd = cmd.decode('utf8')
+        cmd = cmd.decode("utf8")
 
     subprocess.check_call(
         shlex.split(cmd),
@@ -84,19 +78,20 @@ def python_source_code(python_git_url, tmpdir):
 def qa_skip_buildroot(skip_binary_strip):
     if skip_binary_strip:
 
-        os.environ['QA_SKIP_BUILD_ROOT'] = '1'
+        os.environ["QA_SKIP_BUILD_ROOT"] = "1"
 
-    elif 'QA_SKIP_BUILD_ROOT' in os.environ:
+    elif "QA_SKIP_BUILD_ROOT" in os.environ:
 
-        os.environ.pop('QA_SKIP_BUILD_ROOT')
+        os.environ.pop("QA_SKIP_BUILD_ROOT")
 
 
 @pytest.fixture
-def python_config_file(python, skip_binary_strip, use_pip_install,
-                       remove_pycache, tmpdir):
+def python_config_file(
+    python, skip_binary_strip, use_pip_install, remove_pycache, tmpdir
+):
     """Get a config file path."""
-    extra_filename = 'README.rst'
-    json_file = str(tmpdir.join('conf.json'))
+    extra_filename = "README.rst"
+    json_file = str(tmpdir.join("conf.json"))
     config_body = {
         "extensions": {
             "enabled": [
@@ -125,29 +120,29 @@ def python_config_file(python, skip_binary_strip, use_pip_install,
                 extra_filename + ":opt/test-pkg/" + extra_filename + "1",
                 {
                     "src": extra_filename,
-                    "dest": "opt/test-pkg/" + extra_filename + "2"
+                    "dest": "opt/test-pkg/" + extra_filename + "2",
                 },
                 {
                     "src": extra_filename,
                     "dest": "opt/test-pkg/" + extra_filename + "3",
-                    "config": True
+                    "config": True,
                 },
                 {
                     "src": extra_filename,
                     "dest": "opt/test-pkg/" + extra_filename + "4",
-                    "config": "noreplace"
+                    "config": "noreplace",
                 },
                 {
                     "src": extra_filename,
                     "dest": "opt/test-pkg/" + extra_filename + "5",
-                    "doc": True
+                    "doc": True,
                 },
                 {
                     "src": extra_filename,
                     "dest": "opt/test-pkg/" + extra_filename + "6",
                     "doc": False,
-                    "config": False
-                }
+                    "config": False,
+                },
             ]
         },
         "python_venv": {
@@ -158,18 +153,13 @@ def python_config_file(python, skip_binary_strip, use_pip_install,
             "strip_binaries": not skip_binary_strip,
             "use_pip_install": use_pip_install,
             "remove_pycache": remove_pycache,
-            "flags": [
-                "--always-copy",
-                "--activators",
-                "bash,cshell,fish,powershell,python"
-            ]
         },
         "blocks": {
             "post": ("echo 'Hello'",),
             "desc": ("test pkg description",),
-        }
+        },
     }
-    with open(json_file, 'w') as conf_file:
+    with open(json_file, "w") as conf_file:
 
         conf_file.write(json.dumps(config_body))
 


### PR DESCRIPTION
This removes the workaround in the tests that was used to skip nu shell
installation in the virtualenv and updates tests to use the latest
venvctrl version.

The latest version of venvctrl also delcares a dependency on virtualenv
so it no longer needs to be manually installed in the CI configuration.