### PR TITLE
add support for rpm %attr for files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: true
     steps:
       - name: Install deps
-        run: sudo apt update && sudo apt install -y rpm enchant
+        run: sudo apt update && sudo apt install -y rpm enchant-2
       - name: Checkhout
         uses: actions/checkout@v2.4.0
       - name: Setup Python ${{ matrix.pyver }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        pyver: ["3.6.15", "3.7.15", "3.8.16", "3.9.16", "3.10.10"]
       fail-fast: true
     steps:
       - name: Install deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.6.15", "3.7.15", "3.8.16", "3.9.16", "3.10.10"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: true
     steps:
       - name: Install deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     apt:
         packages:
         - rpm
-        - enchant
+        - enchant-2
 install:
     - if [[ "$(python --version 2>&1)" =~ Python\ (2\.*) ]]; then pip install -U jinja2; else echo "Skipping JINJA2 for $(python --version 2>&1)."; fi
     - pip install -rtest-requirements.txt

--- a/rpmvenv/extensions/files/option.py
+++ b/rpmvenv/extensions/files/option.py
@@ -63,7 +63,7 @@ class FileOption(option.Option):
                     file_attr['user'] = '-'
                 if 'group' not in file_attr:
                     file_attr['group'] = '-'
-            elif file_attr is not None: # Erase wrong values
+            elif file_attr is not None:  # Erase wrong values
                 file_attr = None
 
             return RpmFile(src=value['src'],

--- a/rpmvenv/extensions/files/option.py
+++ b/rpmvenv/extensions/files/option.py
@@ -1,5 +1,4 @@
 """Confpy extension that supports using RPM file paths as config options."""
-
 from collections.abc import MutableMapping
 from collections import namedtuple
 
@@ -11,7 +10,11 @@ except NameError:
     basestring = str
 
 RpmFile = namedtuple('RpmFile',
-                     ['src', 'dest', 'file_type', 'file_type_option'])
+                     ['src',
+                      'dest',
+                      'file_type',
+                      'file_type_option',
+                      'file_attr'])
 
 
 class FileOption(option.Option):
@@ -52,10 +55,22 @@ class FileOption(option.Option):
             elif value.get('doc', False):
                 file_type = 'doc'
 
+            file_attr = value.get('attr', None)
+            if file_attr is not None and isinstance(file_attr, MutableMapping):
+                if 'permissions' not in file_attr:
+                    file_attr['permissions'] = '-'
+                if 'user' not in file_attr:
+                    file_attr['user'] = '-'
+                if 'group' not in file_attr:
+                    file_attr['group'] = '-'
+            elif file_attr is not None: # Erase wrong values
+                file_attr = None
+
             return RpmFile(src=value['src'],
                            dest=value['dest'],
                            file_type=file_type,
-                           file_type_option=file_type_option)
+                           file_type_option=file_type_option,
+                           file_attr=file_attr,)
 
         elif isinstance(value, basestring):
             try:
@@ -63,7 +78,8 @@ class FileOption(option.Option):
                 return RpmFile(src=src,
                                dest=dest,
                                file_type=None,
-                               file_type_option=None)
+                               file_type_option=None,
+                               file_attr=None,)
             except ValueError:
                 raise ValueError('The value {0} is missing a :'.format(value))
 

--- a/tests/test_fileoption.py
+++ b/tests/test_fileoption.py
@@ -64,6 +64,7 @@ def test_parse_dict_no_file_type_explicit():
     assert rpm_file.dest == value['dest']
     assert rpm_file.file_type is None
     assert rpm_file.file_type_option is None
+    assert rpm_file.file_attr is None
 
 
 def test_parse_dict_doc_file():
@@ -72,7 +73,7 @@ def test_parse_dict_doc_file():
     value = {
         'src': '/foo/bar',
         'dest': '/etc/foo',
-        'doc': 'foobar'  # anything truthy is okay, value is ignored
+        'doc': 'foobar',  # anything truthy is okay, value is ignored
     }
 
     rpm_file = parser.coerce(value)
@@ -98,6 +99,27 @@ def test_parse_dict_config_file_no_option():
     assert rpm_file.dest == value['dest']
     assert rpm_file.file_type == 'config'
     assert rpm_file.file_type_option is None
+
+
+def test_parse_dict_file_with_attributes():
+    parser = file_opt.FileOption()
+
+    value = {
+        'src': '/foo/bar',
+        'dest': '/etc/foo',
+        'attr': {
+            "permissions": "0644",
+            "user": "testuser"
+        }
+    }
+
+    rpm_file = parser.coerce(value)
+    assert isinstance(rpm_file, file_opt.RpmFile)
+    assert rpm_file.src == value['src']
+    assert rpm_file.dest == value['dest']
+    assert rpm_file.file_type == None
+    assert rpm_file.file_type_option == None
+    assert rpm_file.file_attr == {"permissions": "0644", "user":"testuser", "group":"-"}
 
 
 def test_parse_dict_config_file_with_option():

--- a/tests/test_fileoption.py
+++ b/tests/test_fileoption.py
@@ -117,9 +117,13 @@ def test_parse_dict_file_with_attributes():
     assert isinstance(rpm_file, file_opt.RpmFile)
     assert rpm_file.src == value['src']
     assert rpm_file.dest == value['dest']
-    assert rpm_file.file_type == None
-    assert rpm_file.file_type_option == None
-    assert rpm_file.file_attr == {"permissions": "0644", "user":"testuser", "group":"-"}
+    assert rpm_file.file_type is None
+    assert rpm_file.file_type_option is None
+    assert rpm_file.file_attr == {
+        "permissions": "0644",
+        "user": "testuser",
+        "group": "-"
+        }
 
 
 def test_parse_dict_config_file_with_option():


### PR DESCRIPTION
instead of relying on chmod/chown for files use the %attr directive of rpm. Particularly useful for files_extras

Needed this for a project of mine, so I might as well give back to the community.