### PR TITLE
Pin markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jinja2==2.11.3
+markupsafe==2.0.1
 venvctrl>=0.5.0,<2.0.0
 confpy>=0.11.0,<2.0.0
 semver>=2.9.1,<3.0.0


### PR DESCRIPTION
This dependency updated in 2022 to no longer have the method "soft_unicode". Because we are pinned to a jinja2 version we must also pin to the last compatible markupsafe version for now.