### PR TITLE
Remove nushell warnings in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,6 @@ rpmvenv
 
 -   `NOTE: bdist eggs with scripts <#note-bdist-eggs-with-scripts>`_
 
--   `NOTE: BUILDROOT errors and nushell <#note-buildroot-errors-and-nushell>`_
-
 -   `Testing <#testing>`_
 
 -   `License <#license>`_
@@ -420,36 +418,6 @@ which switches the installation method from `python setup.py install` to
 `pip install .`. These two methods result in different installation behavior
 because `pip` will always generate a wheel rather than an egg which does not
 suffer from this issue.
-
-NOTE: BUILDROOT errors and nushell
-==================================
-
-If you are using recent versions of virtualenv then you may see error messages
-like this::
-
-    /tmp/rpmvenvz_kldppd/BUILDROOT/test-pkg-1.2.3.4-1.x86_64/usr/share/python/test-pkg-venv/bin/activate.nu
-    Found '/tmp/rpmvenvz_kldppd/BUILDROOT/test-pkg-1.2.3.4-1.x86_64' in installed files; aborting
-
-The issue is that virtualenv recently changed the contents of the nushell
-activation script that is included by default in every virtualenv. There's an
-`issue <https://github.com/kevinconway/venvctrl/issues/23>`_ tracking this for
-`venvctrl`, which is the tool used by `rpmvenv` to rewrite virtualenv paths.
-
-In the meantime, the easiest workaround is to disable nushell if you aren't
-using it. To do this, set your `python_venv.flags` option like this:
-
-.. code-block:: javascript
-
-    {
-        "python_venv": {
-            "flags": ["--always-copy", "--activators", "bash,python"]
-        }
-    }
-
-This disables the generation of all activation scripts except one for bash and
-Python. See `the virtualenv docs
-<https://virtualenv.pypa.io/en/latest/cli_interface.html#activators>`_ for the
-full set of possible activators if you need more than bash and Python.
 
 Testing
 =======

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2==2.11.3
 markupsafe==2.0.1
-venvctrl>=0.5.0,<2.0.0
+venvctrl>=0.6.0,<2.0.0
 confpy>=0.11.0,<2.0.0
 semver>=2.9.1,<3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def python_config_file(
         },
         "python_venv": {
             "cmd": "virtualenv",
-            "flags": ["--always-copy", "--activators", "bash,python"],
+            "flags": ["--always-copy"],
             "name": "test-pkg-venv",
             "path": "/usr/share/python",
             "python": python,


### PR DESCRIPTION
There's no change to rpmvenv but a recent patch to venvctrl has removed the need for nushell related workarounds. Users pulling in the 0.6.0 or later version of venvctrl will automatically have the patch applied. Users no longer need to disable nushell for rpmvenv to work. This may change again in the future if virtualenv makes more changes to activation scripts.